### PR TITLE
Remember me and timeout update

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,9 +1,12 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  include Devise::Controllers::Rememberable
+
   def google_oauth2
       # You need to implement the method below in your model (e.g. app/models/user.rb)
       @user = User.from_omniauth(request.env['omniauth.auth'])
 
       if @user.persisted?
+        remember_me(@user)
         flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Google'
         sign_in_and_redirect @user, event: :authentication
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable, :trackable,
+    :recoverable, :rememberable, :validatable, :trackable, :timeoutable,
     :lockable, :omniauthable, omniauth_providers: [:google_oauth2]
 
   before_create :add_collection

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -149,7 +149,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = 1.year
+  config.remember_for = 6.months
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
@@ -173,7 +173,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 1.year 
+  config.timeout_in = 1.day
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
remember_me - enable this behavior when logging in via omniauth
user - add timeoutable to unlock functionality of the timeout_in config value

# Description

Timeoutable - this attribute is required on the user model in order to enable the 'timeout_in' devise config value.  Setting this to a day as those who log in by standard username and password have a remember me checkbox that functions.  So if someone wants to opt out that way they can, but still won't have to log in multiple times per league day

Omniauth remember_me - this will enable remember_me behavior when using omniauth.  Important to note that there's no way to opt out of it here.  If one logs off it will reset the remember_created_at in the db.
As far as why remember_me can't be toggled with the checkbox: https://github.com/heartcombo/devise/wiki/Omniauthable,-sign-out-action-and-rememberable
The checkbox value isn't passed by devise, unfortunately so it's all or nothing in that respect.  I'd prefer not to have session timeout be really long as that seems like a not so good practice.

updating remember_me time frame to be 6 months, so about once a season log in requirement seems reasonable.

##Scope
User log in

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
