### PR TITLE
feat: safari detection and fallbacks

### DIFF
--- a/app/javascript/stylesheets/footer/footer.scss
+++ b/app/javascript/stylesheets/footer/footer.scss
@@ -5,13 +5,11 @@
 
     width: 100%;
     height: var(--footer-height);
-    background-color: var(--color-fill-neutral);
+
     --footer-corner-color: hsl(from var(--color-fill-neutral) h s calc(l + 10) / 0.2);
     --footer-central-color: hsl(from var(--color-fill-neutral) h s l / 0.4);
-    @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-        --footer-corner-color: hsl(from var(--color-fill-neutral) h s calc(l + 10%) / 0.5);
-    }
-    background: linear-gradient(
+    background-color: var(--footer-central-color);
+    background-image: linear-gradient(
         56deg,
         var(--color-fill-neutral),
         var(--footer-central-color) 40%,

--- a/app/javascript/stylesheets/navigation/navigation.scss
+++ b/app/javascript/stylesheets/navigation/navigation.scss
@@ -14,13 +14,11 @@
     box-shadow: 0 2px 2px 0 hsl(from var(--color-fill-neutral) h s l / 0.2), 0 3px 1px -2px rgba(0, 0, 0, 0.3),
         0 1px 5px 0 hsl(from var(--color-fill-neutral) h s l / 0.4);
     z-index: 99;
-    background-color: var(--color-fill-neutral);
+
     --nav-corner-color: hsl(from var(--color-fill-neutral) h s calc(l + 10) / 0.5);
-    --nav-central-color: hsl(from var(--color-fill-neutral) h s l / 0.7);
-    @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-        --nav-corner-color: hsl(from var(--color-fill-neutral) h s calc(l + 10%) / 0.5);
-    }
-    background: linear-gradient(
+    --nav-central-color: hsl(from var(--color-fill-neutral) h s l / 0.5);
+    background-color: var(--nav-central-color);
+    background-image: linear-gradient(
         56deg,
         var(--color-fill-neutral),
         var(--nav-central-color) 30%,

--- a/app/javascript/stylesheets/rankings/rankings.scss
+++ b/app/javascript/stylesheets/rankings/rankings.scss
@@ -160,16 +160,8 @@
         --rankings-central-color: hsl(
             from var(--color-fill-neutral) h s calc(l + var(--rankings-button-lightness-shift)) / 0.6
         );
-        @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-            --rankings-button-lightness-shift: 0%;
-            --rankings-corner-color: hsl(
-                from var(--color-fill-neutral) h s calc(l + 15% + var(--rankings-button-lightness-shift)) / 0.4
-            );
-            --rankings-central-color: hsl(
-                from var(--color-fill-neutral) h s calc(l + var(--rankings-button-lightness-shift)) / 0.6
-            );
-        }
-        background: linear-gradient(
+        background-color: var(--rankings-central-color);
+        background-image: linear-gradient(
             56deg,
             var(--color-fill-neutral),
             var(--rankings-central-color) 20%,
@@ -203,12 +195,6 @@
         --rankings-corner-color: hsl(
             from var(--color-fill-neutral) h s calc(l + 15 + var(--rankings-button-lightness-shift)) / 0.2
         );
-        @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-            --rankings-button-lightness-shift: 0%;
-            --rankings-corner-color: hsl(
-                from var(--color-fill-neutral) h s calc(l + 15% + var(--rankings-button-lightness-shift)) / 0.2
-            );
-        }
     }
 
     &__player {
@@ -316,4 +302,8 @@
         opacity: 0;
         pointer-events: none;
     }
+}
+
+.safari .rankings__user-button.rankings__user-button--unranked.button {
+    background-color: var(--rankings-central-color);
 }

--- a/app/javascript/stylesheets/sitewide/button.scss
+++ b/app/javascript/stylesheets/sitewide/button.scss
@@ -6,9 +6,6 @@ a.button,
     --button-lightness-shift-safari: 0%;
     --button-background-color-base: var(--color-fill-theme);
 
-    @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-        --button-lightness-shift: var(--button-lightness-shift-safari);
-    }
     -webkit-tap-highlight-color: transparent;
     align-items: center;
     background-color: hsl(
@@ -111,5 +108,4 @@ a.button,
         transition-property: all;
         transition-timing-function: ease-in-out;
     }
-    
 }

--- a/app/javascript/stylesheets/sitewide/color-library.scss
+++ b/app/javascript/stylesheets/sitewide/color-library.scss
@@ -1,7 +1,6 @@
 :root {
     //Current Theme Values
     --color-theme: hsl(190, 37%, 51%);
-    // --color-theme: hsl(298, 44%, 60%);
     --color-dark: hsl(from var(--color-theme) h s calc(l - 40));
     --color-light: hsl(from var(--color-theme) h s calc(l + 40));
     --color-site-background: hsl(from var(--color-theme) h calc(s - 10) calc(l + 50));
@@ -34,14 +33,19 @@
     --color-red-mana: hsl(19, 66%, 68%);
     --color-green-mana: hsl(100, 55%, 43%);
     --color-colorless-mana: hsl(30, 8%, 77%);
-    //Safari Specific Values
-    @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-        --color-dark: hsl(from var(--color-theme) h s calc(l - 40%));
-        --color-light: hsl(from var(--color-theme) h s calc(l + 40%));
-        --color-site-background: hsl(from var(--color-theme) h calc(s - 10%) calc(l + 50%));
-        --color-lightness-shift-basis: 1%;
-        --color-text-theme: hsl(from var(--color-fill-theme) h s calc(l - 30%));
-        --color-text-negative: hsl(from var(--color-fill-negative) h s calc(l - 30%));
-        --color-fill-theme-highlight: hsl(from var(--color-fill-theme) h s calc(l + 15%));
-    }
+}
+
+//Safari Specific Values
+.safari {
+    --color-dark: hsl(190, 37%, 11%);
+    --color-light: hsl(190, 37%, 91%);
+    --color-site-background: hsl(190, 27%, 101%);
+    --color-lightness-shift-basis: 1%;
+    --color-text-theme: hsl(190, 37%, 21%);
+    --color-text-neutral: hsl(190, 37%, 11%);
+    --color-text-neutral: hsl(190, 37%, 91%);
+    --color-text-negative: hsl(2, 100%, 20%);
+    --color-fill-theme-highlight: hsl(190, 37%, 66%);
+    --color-fill-inverse: hsl(190, 37%, 91%);
+    --color-fill-neutral: hsl(190, 37%, 11%);
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,18 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+ <script>         
+            document.addEventListener("DOMContentLoaded", function() {
+            console.log("checking version")
+            var ua = navigator.userAgent;
+            var isSafari = /^((?!chrome|android).)*safari/i.test(ua);
+           
+            console.log("is safari: " + isSafari)
+            if (isSafari) {
+              document.body.classList.add('safari');
+            }
+          });
+</script>
   </head>
   <body>
     <% if user_signed_in? %>


### PR DESCRIPTION
# Description

Adds a detection script to assign a .safari  class if desktop safari or an IOS device is being used
- adds hard set color safari fixes that work with both version 17 safari and older IOS devices
- Apply them to all safari versions, although we could probably get deeper version detecting as Safari 18 better handles relative colors, 

##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
